### PR TITLE
Project Load fix.

### DIFF
--- a/Shooting/src/index.js
+++ b/Shooting/src/index.js
@@ -198,8 +198,8 @@ document.addEventListener('visibilitychange', () => {
     animate();
   }
 });
-
-if (!gameOver && enemyIntervalId && animationFrameId) {
+// The document.hidden check helps to ensure that no enemies are spawned or animation runs when the project loads as the user is on another tab, otherwise, everything loads successfully.
+if (!gameOver && !document.hidden) {
   spawnEnemies(canvas, player);
   animate();
 }


### PR DESCRIPTION
## What does this PR do?
- [x] It fixes the issue where the game does not load up if the user is in the project tab while the project loads up for the first time. It ensures that the game does not load up if the user is in a different tab while the project loads up, but it loads up fine otherwise.